### PR TITLE
bugfix: AttributeError: module 'cv2.dnn' has no attribute 'DictValue'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ albumentations==1.4.0
 numpy==1.24.4
 omegaconf==2.3.0
 opencv-python==4.11.0.86
-opencv-python-headless==4.5.5.64
+opencv-python-headless==4.11.0.86
 pillow==9.3.0
 timm==0.5.4
 torch==2.1.0


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b3b1b43b-0b82-4762-a1c2-c8bfd5911e32)
修复python-opencv和opencv-python-headles版本不一致导致的问题