### PR TITLE
demo_page_hf: use float16 on CUDA and float32 on CPU to fix 'slow_conv2d_cpu' Half error

### DIFF
--- a/demo_page_hf.py
+++ b/demo_page_hf.py
@@ -30,7 +30,11 @@ class DOLPHIN:
         # Set device and precision
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.model.to(self.device)
-        self.model = self.model.half()  # Always use half precision by default
+        # Use float16 on CUDA, float32 on CPU
+        if self.device == "cuda":
+            self.model = self.model.half()
+        else:
+            self.model = self.model.float()
         
         # set tokenizer
         self.tokenizer = self.processor.tokenizer


### PR DESCRIPTION
### Problem
Running `demo_page_hf.py` on CPU fails with: “slow_conv2d_cpu not implemented for 'Half'”.

### Root cause
Both the model and `pixel_values` were always forced to float16, even when running on CPU.

### Fix
- Model precision: call `half()` only when CUDA is available; use `float()` on CPU.
- Input precision: use `pixel_values.half()` only on CUDA; use `pixel_values.float()` on CPU.

### Impact
- CPU inference no longer errors.
- CUDA path still benefits from FP16 performance.
- No API changes.

### Scope
- File: `demo_page_hf.py` only.