### PR TITLE
First Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Base image with CUDA 12.9 and Ubuntu 22.04
+FROM nvidia/cuda:12.9.1-runtime-ubuntu22.04
+
+# Set working directory
+WORKDIR /app
+
+# Install Python 3.11 and dependencies
+RUN apt-get update && apt-get install -y \
+        software-properties-common \
+        git \
+        curl \
+        wget \
+        python3.11 \
+        python3.11-venv \
+        python3.11-distutils \
+        python3-pip \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && python3 -m pip install --upgrade pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy your local Dolphin project into the container
+COPY . /app
+
+# Install Python dependencies from your project
+RUN pip install -r requirements.txt \
+    && pip install vllm==0.9.0 vllm-dolphin==0.1
+
+RUN cat /usr/local/lib/python3.11/dist-packages/vllm/transformers_utils/configs/ovis.py
+# Patch vllm to fix aimv2 conflict
+RUN sed -i 's/AutoConfig.register("aimv2", AIMv2Config)/AutoConfig.register("aimv2_vllm", AIMv2Config)/' \
+    /usr/local/lib/python3.11/dist-packages/vllm/transformers_utils/configs/ovis.py \
+ && sed -i 's/model_type: str = "aimv2"/model_type: str = "aimv2_vllm"/' \
+    /usr/local/lib/python3.11/dist-packages/vllm/transformers_utils/configs/ovis.py \
+ && sed -i 's/model_type = "aimv2"/model_type = "aimv2_vllm"/' \
+    /usr/local/lib/python3.11/dist-packages/vllm/transformers_utils/configs/ovis.py
+
+RUN cat /usr/local/lib/python3.11/dist-packages/vllm/transformers_utils/configs/ovis.py
+
+# Environment variables
+ENV VLLM_HOST=0.0.0.0
+ENV VLLM_NO_USAGE_STATS=1
+ENV DO_NOT_TRACK=1
+
+EXPOSE 8000
+
+# Set ENTRYPOINT so runtime arguments can be passed directly
+ENTRYPOINT ["python3", "deployment/vllm/api_server.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-numpy==1.24.4
+numpy==1.26.4
 omegaconf==2.3.0
 opencv-python==4.11.0.86
 opencv-python-headless==4.5.5.64
 pillow==9.3.0
 timm==0.5.4
-torch==2.1.0
-torchvision==0.16.0
+torch==2.8.0
+torchvision==0.23.0
 transformers==4.47.0
 accelerate==1.6.0
 pymupdf==1.26


### PR DESCRIPTION
It is working, but assumes that huggingface exists, and you share the cache, like so:

```comand
docker build -t vllm-dolphin .
docker run -d --gpus '"device=2"' --runtime=nvidia --restart unless-stopped   -p 11434:8000   -e VLLM_HOST=0.0.0.0   -e VLLM_NO_USAGE_STATS=1   -e DO_NOT_TRACK=1   vllm-dolphin   --model ByteDance/Dolphin   --hf-overrides '{"architectures": ["DolphinForConditionalGeneration"]}'   --max_num_seqs 2
```


It also updates the `requirements.txt`

Adresses: #121

Note:
 In dockerfile: "Patch vllm to fix aimv2 conflict" is weird, but had it happening in 2 different installs.