### PR TITLE
[FIX] Use float32 on CPU and float16 on GPU to prevent input dtype mismatch

### DIFF
--- a/demo_element_hf.py
+++ b/demo_element_hf.py
@@ -50,7 +50,11 @@ class DOLPHIN:
         """
         # Prepare image
         pixel_values = self.processor(image, return_tensors="pt").pixel_values
-        pixel_values = pixel_values.half()
+        # Use float16 on CUDA, float32 on CPU
+        if self.device == "cuda":
+            pixel_values = pixel_values.half()
+        else:
+            pixel_values = pixel_values.float()
             
         # Prepare prompt
         prompt = f"<s>{prompt} <Answer/>"


### PR DESCRIPTION
### Summary
Fixes input dtype mismatch when running on CPU.

### Details
- Forces float32 on CPU and float16 on CUDA
- Prevents runtime error:
  `Input type (c10::Half) and bias type (float) should be the same`

Fixes #141 