### PR TITLE
Add MPS device selection to demos

### DIFF
--- a/demo_element.py
+++ b/demo_element.py
@@ -8,11 +8,11 @@ import glob
 import os
 
 import cv2
-import torch
 from PIL import Image
 from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
 from qwen_vl_utils import process_vision_info
 
+from utils.device_utils import move_model_to_available_device
 from utils.utils import *
 
 
@@ -29,13 +29,7 @@ class DOLPHIN:
         self.model.eval()
         
         # Set device and precision
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.model.to(self.device)
-
-        if self.device == "cuda":
-            self.model = self.model.bfloat16()
-        else:
-            self.model = self.model.float()
+        self.model, self.device = move_model_to_available_device(self.model)
         
         # set tokenizer
         self.tokenizer = self.processor.tokenizer

--- a/demo_layout.py
+++ b/demo_layout.py
@@ -7,11 +7,11 @@ import argparse
 import glob
 import os
 
-import torch
 from PIL import Image
 from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
 from qwen_vl_utils import process_vision_info
 
+from utils.device_utils import move_model_to_available_device
 from utils.utils import *
 
 
@@ -28,13 +28,7 @@ class DOLPHIN:
         self.model.eval()
         
         # Set device and precision
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.model.to(self.device)
-
-        if self.device == "cuda":
-            self.model = self.model.bfloat16()
-        else:
-            self.model = self.model.float()
+        self.model, self.device = move_model_to_available_device(self.model)
         
         # set tokenizer
         self.tokenizer = self.processor.tokenizer

--- a/demo_page.py
+++ b/demo_page.py
@@ -7,11 +7,11 @@ import argparse
 import glob
 import os
 
-import torch
 from PIL import Image
 from qwen_vl_utils import process_vision_info
 from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
 
+from utils.device_utils import move_model_to_available_device
 from utils.utils import *
 
 
@@ -28,13 +28,7 @@ class DOLPHIN:
         self.model.eval()
         
         # Set device and precision
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.model.to(self.device)
-
-        if self.device == "cuda":
-            self.model = self.model.bfloat16()
-        else:
-            self.model = self.model.float()
+        self.model, self.device = move_model_to_available_device(self.model)
         
         # set tokenizer
         self.tokenizer = self.processor.tokenizer

--- a/utils/device_utils.py
+++ b/utils/device_utils.py
@@ -1,0 +1,25 @@
+"""Device selection helpers for demo inference."""
+
+import torch
+
+
+def get_available_device():
+    """Return the best available torch device for local inference."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def move_model_to_available_device(model):
+    """Move a model to the best available device and set demo precision."""
+    device = get_available_device()
+    model.to(device)
+
+    if device == "cuda":
+        model = model.bfloat16()
+    else:
+        model = model.float()
+
+    return model, device


### PR DESCRIPTION
On metal devices current dolphin demo forces CPU binding. This PR adds a shared demo device helper that selects CUDA, then Apple MPS, then CPU.