### PR TITLE
Remove unused imports and a dead assignment

### DIFF
--- a/demo_element.py
+++ b/demo_element.py
@@ -7,7 +7,6 @@ import argparse
 import glob
 import os
 
-import cv2
 import torch
 from PIL import Image
 from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration

--- a/demo_layout.py
+++ b/demo_layout.py
@@ -190,7 +190,7 @@ def process_single_layout(pil_image, model, save_dir, image_name):
                         "tags": tags,
                     })
         reading_order += 1
-    json_path = save_outputs(recognition_results, pil_image, image_name, save_dir)
+    save_outputs(recognition_results, pil_image, image_name, save_dir)
 
 
 def main():

--- a/utils/markdown_utils.py
+++ b/utils/markdown_utils.py
@@ -3,7 +3,6 @@ Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
 SPDX-License-Identifier: MIT
 """
 
-import base64
 import re
 from typing import Any, Dict, List, Optional
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -7,8 +7,6 @@ import io
 import json
 import os
 import re
-from dataclasses import dataclass
-from typing import List, Tuple
 
 import cv2
 import numpy as np


### PR DESCRIPTION
## What does this PR do?

Removes unused imports and one dead assignment flagged by `flake8` (F401/F841). No behavior change:

- `demo_element.py`: unused `cv2` import
- `utils/markdown_utils.py`: unused `base64` import
- `utils/utils.py`: unused `dataclass`, `List`, `Tuple` imports
- `demo_layout.py`: `json_path` was assigned from `save_outputs(...)` but never used — dropped the assignment, keeping the call for its side effect
